### PR TITLE
Remove Python setup from workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,14 +26,6 @@ jobs:
         uses: quarto-dev/quarto-actions/setup@v2
 
       # Décommente un bloc si le site exécute du code pendant le render
-      # (Python)
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-          cache: 'pip'
-      - run: |
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-
       # (R + renv)
       - uses: r-lib/actions/setup-r@v2
       - uses: r-lib/actions/setup-renv@v2


### PR DESCRIPTION
## Summary
- simplify GitHub Actions workflow for R-only project by dropping Python setup and pip install steps

## Testing
- `apt-get install -y quarto` *(fails: Unable to locate package)*
- `wget -O /tmp/quarto.deb https://quarto.org/download/latest/quarto-linux-amd64.deb` *(fails: Proxy tunneling failed)*

------
https://chatgpt.com/codex/tasks/task_e_689b482553bc8322a18f36ffc0c17081