### PR TITLE
chore: install rmarkdown in workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,9 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
       - uses: r-lib/actions/setup-renv@v2
 
+      - name: Install rmarkdown
+        run: Rscript -e 'install.packages("rmarkdown")'
+
       - name: Render Quarto project
         run: |
           quarto check install


### PR DESCRIPTION
## Summary
- install rmarkdown before rendering Quarto project

## Testing
- `yamllint .github/workflows/publish.yml`


------
https://chatgpt.com/codex/tasks/task_e_689b4c84ba388322b4cb19daac35696b