### PR TITLE
Handle Ubuntu 24.04 runner and fix mission setup

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,24 @@ jobs:
       - name: Setup Quarto
         uses: quarto-dev/quarto-actions/setup@v2
 
+      - name: Detect runner OS
+        run: |
+          case "$RUNNER_OS" in
+            Linux)
+              echo "BUNDLE_EXT=linux.tar.gz" >> $GITHUB_ENV
+              ;;
+            Windows)
+              echo "BUNDLE_EXT=win.msi" >> $GITHUB_ENV
+              ;;
+            macOS)
+              echo "BUNDLE_EXT=mac.pkg" >> $GITHUB_ENV
+              ;;
+            *)
+              echo "$RUNNER_OS not supported"
+              exit 1
+              ;;
+          esac
+
       # Décommente un bloc si le site exécute du code pendant le render
       # (R + renv)
       - uses: r-lib/actions/setup-r@v2

--- a/atelier1_reg_lin/missions/M2_interpretation.qmd
+++ b/atelier1_reg_lin/missions/M2_interpretation.qmd
@@ -4,12 +4,15 @@ format: html
 ---
 
 ```{r}
-#source("../../utils/requirements.R")
-library(AmesHousing); set.seed(42); library(dplyr); library(broom)
-ames <- make_ames()
-idx <- sample(seq_len(nrow(ames)), size = floor(.8*nrow(ames)))
-train <- ames[idx,]; test <- ames[-idx,]
-mod <- lm(Sale_Price ~ Gr_Liv_Area + Overall_Qual + Year_Built + Full_Bath + Garage_Cars, data=train)
+source("../../utils/requirements.R")
+set.seed(42)
+ames <- AmesHousing::make_ames()
+idx <- sample(seq_len(nrow(ames)), size = floor(.8 * nrow(ames)))
+train <- ames[idx, ]; test <- ames[-idx, ]
+mod <- lm(
+  Sale_Price ~ Gr_Liv_Area + Overall_Qual + Year_Built + Full_Bath + Garage_Cars,
+  data = train
+)
 ```
 
 ## Tâches


### PR DESCRIPTION
## Summary
- add OS detection to support Ubuntu runners in GitHub Actions workflow
- source common requirements and tidy the setup chunk of Mission 2 document

## Testing
- `R -q -e 'source("utils/requirements.R"); AmesHousing::make_ames(); cat("ok\n")'` *(fails: unable to download packages)*
- `wget https://quarto.org/download/latest/quarto-linux-amd64.deb` *(fails: proxy forbids connection)*

------
https://chatgpt.com/codex/tasks/task_e_689b6311ee5c8322ab953aa3d0205232