### PR TITLE
Définir HTML comme format par défaut du site

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -17,6 +17,8 @@ website:
         file: utils/setup-packages.qmd
 
 format:
+  html:
+    default: true
   revealjs:
     theme: [default]
     css: styles/ulaval.css

--- a/index.qmd
+++ b/index.qmd
@@ -1,5 +1,6 @@
 ---
 title: "Accueil"
+format: html
 ---
 
 Bienvenue sur le site des ateliers EIOM consacrés à la régression linéaire multiple et à la régression logistique.


### PR DESCRIPTION
## Summary
- Fix site configuration to render pages as HTML by default while retaining Reveal.js options for slides.
- Add explicit HTML format front matter to the homepage.

## Testing
- `quarto render` *(fails: missing R package 'knitr' and 'rmarkdown')*


------
https://chatgpt.com/codex/tasks/task_e_68a5bbdc99948322b75318b5f5d7b182